### PR TITLE
fix: copy .npmrc file to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /home/app
 COPY ./src ./src
 COPY ./package*.json ./
 COPY ./tsconfig.json ./
+ARG GH_TOKEN
 
 RUN npm ci --ignore-scripts
 RUN npm run build
@@ -21,6 +22,7 @@ LABEL stage=pre-prod
 # To filter out dev dependencies from final build
 
 COPY package*.json ./
+ARG GH_TOKEN
 RUN npm ci --omit=dev --ignore-scripts
 
 FROM ${RUN_IMAGE} AS run-env

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /home/app
 COPY ./src ./src
 COPY ./package*.json ./
 COPY ./tsconfig.json ./
+COPY .npmrc ./
 ARG GH_TOKEN
 
 RUN npm ci --ignore-scripts
@@ -22,6 +23,7 @@ LABEL stage=pre-prod
 # To filter out dev dependencies from final build
 
 COPY package*.json ./
+COPY .npmrc ./
 ARG GH_TOKEN
 RUN npm ci --omit=dev --ignore-scripts
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+version: "2"
+services:
+  node:
+    container_name: event-sidecar
+    build:
+      context: .
+      args:
+        - GH_TOKEN
+    restart: "no"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@ version: "2"
 services:
   node:
     container_name: event-sidecar
+    image: example.io/sidecar-rel-1-0-0:1.0.0
     build:
       context: .
       args:


### PR DESCRIPTION
Adds a docker compose file which can be used to spin up the image:

`GH_TOKEN=foobar docker compose build`